### PR TITLE
Add Webpack code splitting for vendors and geodata

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = (env) => {
     devtool: isDevelopement ? 'inline-cheap-source-map' : false,
     output: {
       filename: isDevelopement ? 'bundle.js' : 'bundle-[contenthash].js',
+      chunkFilename: isDevelopement ? '[name].chunk.js' : '[name].[contenthash].chunk.js',
       path: path.resolve(__dirname, 'dist'),
       clean: true,
       assetModuleFilename: '[name][ext]',
@@ -97,6 +98,22 @@ module.exports = (env) => {
     ],
     optimization: {
       minimizer: [new TerserPlugin(), new CssMinimizerPlugin()],
+      splitChunks: {
+        chunks: 'all',
+        cacheGroups: {
+          vendor: {
+            test: /[\\/]node_modules[\\/]/,
+            name: 'vendors',
+            chunks: 'all',
+          },
+          data: {
+            test: /[\\/]data[\\/]/,
+            name: 'geodata',
+            chunks: 'all',
+            minSize: 0,
+          },
+        },
+      },
     },
   };
 


### PR DESCRIPTION
Split the monolithic bundle into 3 separate cacheable chunks:
- vendors (203KB): node_modules dependencies like Leaflet
- geodata (706KB): GeoJSON data files
- main (19KB): application code

This improves caching - users won't re-download vendor libraries when app code changes.